### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ redis-completion is capable of storing a large number of phrases and quickly
 searching them for matches.  Rich data can be stored and retrieved, helping you
 avoid trips to the database when retrieving search results.
 
-check out the `documentation <http://redis-completion.rtfd.org/>`_ for more info.
+check out the `documentation <https://redis-completion.readthedocs.io/>`_ for more info.
 
 usage
 -----
@@ -79,4 +79,4 @@ Install via git::
 schema
 ------
 
-.. image:: http://redis-completion.readthedocs.org/en/latest/_images/schema.jpg
+.. image:: https://redis-completion.readthedocs.io/en/latest/_images/schema.jpg


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.